### PR TITLE
Loosen the Intent Filter so that it also works on higher Android versions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,22 +75,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="file" />
+                <data android:scheme="content" />
                 <data android:mimeType="*/*" />
-                <data android:host="*" />
-                <data android:pathPattern=".*\\.txt" />
-                <data android:pathPattern=".*\\.html" />
-                <data android:pathPattern=".*\\.css" />
-                <data android:pathPattern=".*\\.js" />
-                <data android:pathPattern=".*\\.md"/>
-                <data android:pathPattern=".*\\.php" />
-                <data android:pathPattern=".*\\.py" />
-                <data android:pathPattern=".*\\.org" />
-            </intent-filter>
-            <intent-filter >
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="file" />
-                <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
As it is nearly impossible to collect all text-based file types, and the `intent-filter` wasn't working since >= Android 6 anymore at all, as the `content` scheme is used instead of `file`, we should make the `intent-filter` less restrictive. This enables to launch ViperEdit from within the file manager...

![Screenshot_20210806_150444](https://user-images.githubusercontent.com/64581222/128515285-54717d2c-4353-49ed-88f8-a201a1ed99bb.jpg)
