### PR TITLE
Further optimize intent filter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,11 +60,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:mimeType="text/plain" />
-                <data android:mimeType="text/markdown" />
-                <data android:mimeType="text/css" />
+                <data android:mimeType="text/*" />
                 <data android:mimeType="application/javascript" />
                 <data android:mimeType="application/json" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/xhtml+xml" />
+                <data android:mimeType="application/xml" />
+                <data android:mimeType="application/gpx" />
+                <data android:mimeType="application/gpx+xml" />
                 <data android:host="*" />
             </intent-filter>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,14 @@
 
                 <data android:scheme="file" />
                 <data android:scheme="content" />
-                <data android:mimeType="*/*" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="application/javascript" />
+                <data android:mimeType="application/json" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/xhtml+xml" />
+                <data android:mimeType="application/xml" />
+                <data android:mimeType="application/gpx" />
+                <data android:mimeType="application/gpx+xml" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
My PR #14 was a bit too loose.  viper-edit was suggested for everything. So trying to cover only these MIME types which really make sense...

APK files - shouldn't be shown: `application/vnd.android.package-archive`
Music files - shouldn't be shown: `audio/*`
Pictures - shouldn't be shown: `image/*`
Movies - shouldn't be shown: `video/*`

![grafik](https://user-images.githubusercontent.com/64581222/136659129-a3335baa-0cc9-43a9-a3f9-da36e3bd5d78.png)
